### PR TITLE
Add protocol and domain parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ You can also manually set each of the following optional options:
 - SHA
 - Default Branch (master by default)
 - Branch Name
+- Domain Name (github.com by default)
+- Protocol (https by default)
 
 ```ruby
-Glimpse.into Glimpse::Views::Git, :sha => '740f6b7b11b8717efaf51ddb98ce23394544f7e0', :default_branch => 'rails4.0', :branch_name => 'integration'
+Glimpse.into Glimpse::Views::Git, :sha => '740f6b7b11b8717efaf51ddb98ce23394544f7e0', :default_branch => 'rails4.0', :branch_name => 'integration', :domain => 'git.example.com', :protocol => 'http'
 ```
 
 ## Using Glimpse::Git on Heroku

--- a/lib/glimpse/views/git.rb
+++ b/lib/glimpse/views/git.rb
@@ -3,12 +3,14 @@ module Glimpse
     class Git < View
       # A view to get some insight into the current state of git
       # for your project. It gives you the sha, branch, and compare
-      # url on GitHub.
+      # url.
       #
-      # nwo             - The GitHub repository (name with owner).
+      # nwo             - The repository (name with owner).
       # default_branch  - master may not be your default branch.
       # branch_name     - The current branch name (Optional).
       # sha             - The current SHA for git (Optional).
+      # domain          - Domain name of the location of the repository (Default: github.com).
+      # protocol        - The protocol to use in the compare_url (Default: https).
       #
       # Returns Glimpse::Views::Git
       def initialize(options = {})
@@ -16,6 +18,8 @@ module Glimpse
         @default_branch = options.fetch(:default_branch, 'master')
         @branch_name = options.delete(:branch_name)
         @sha = options.delete(:sha)
+        @domain = options.fetch(:domain, 'github.com')
+        @protocol = options.fetch(:protocol, 'https')
       end
 
       def nwo?
@@ -37,7 +41,7 @@ module Glimpse
       end
 
       def compare_url
-        "https://github.com/#{@nwo}/compare/#{@default_branch}...#{sha}"
+        "#{@protocol}://#{@domain}/#{@nwo}/compare/#{@default_branch}...#{sha}"
       end
     end
   end


### PR DESCRIPTION
This adds optional params for domain and protocol for people who may not be using GitHub, like GitLab or GitHub Enterprise (I have no experience with GitHub Enterprise so this is purely a guess that the compare URL would be the same).

Domain defaults to github.com and protocol defaults to https.
