### PR TITLE
compare_url now displayed

### DIFF
--- a/app/views/peek/views/_git.html.erb
+++ b/app/views/peek/views/_git.html.erb
@@ -1,6 +1,6 @@
 <div class="bucket">
   <%= view.branch_name %>
-  <span class="hidden">
+  <span>
     <% if view.nwo? %>
       <a href="<%= view.compare_url %>" target="_blank"><%= view.short_sha %></a>
     <% else %>


### PR DESCRIPTION
Is there a reason to have the compare url hidden ?
