### PR TITLE
Add support for heroku dyno metadata env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,14 @@ Unfortunately Heroku [removes](https://devcenter.heroku.com/articles/slug-compil
 the .git directory during slug compilation which doesn't make it possible to
 view the current deployed SHA or branch.
 
-The one workaround is to set the GIT_SHA and GIT_BRANCH ENV variables within
+One workaround is to set the GIT_SHA and GIT_BRANCH ENV variables within
 your deploy process.
+
+An alternative workaround is to use the runtime dyno metadata lab flag:
+
+    $ heroku labs:enable runtime-dyno-metadata -a <app name>
+
+Then, Peek can display the current Heroku release and sha.
 
 ## Contributing
 

--- a/lib/peek/views/git.rb
+++ b/lib/peek/views/git.rb
@@ -26,14 +26,16 @@ module Peek
         !!@nwo
       end
 
-      # Fetch the current branch name.
+      # Fetch the current branch name or heroku release version.
       def branch_name
-        @branch_name ||= ENV['GIT_BRANCH'] || `git rev-parse --abbrev-ref HEAD`.chomp
+        @branch_name ||= ENV['GIT_BRANCH'] || ENV['HEROKU_RELEASE_VERSION']
+        @branch_name ||= `git rev-parse --abbrev-ref HEAD`.chomp
       end
 
       # Fetch the current sha if one isn't present.
       def sha
-        @sha ||= ENV['GIT_SHA'] || `git rev-parse HEAD`.chomp
+        @sha ||= ENV['HEROKU_SLUG_COMMIT'] || ENV['GIT_SHA']
+        @sha ||= `git rev-parse HEAD`.chomp
       end
 
       def short_sha


### PR DESCRIPTION
A good alternative to just requiring GIT_SHA and GIT_BRANCH is to enable
the Heroku runtime dyno metadata lab flag. It automatically sets
properties about the current deploy and exposes them in ENV variables.

See: https://devcenter.heroku.com/articles/dyno-metadata